### PR TITLE
[TF-1464]: Record non-TF Events

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,7 +72,10 @@
                     "colored",
                     "mmps",
                     "nulled",
-                    "castedKey"
+                    "castedKey",
+                    "touchstart",
+                    "touchmove",
+                    "touchend"
                 ],
                 "skipWordIfMatch": ["^pointer.*$", "(\\S+(32|64)+)"],
                 "minLength": 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New API to reset the interaction settings to their defaults.
 - `SVGCursor.SetCursorOptimise(bool)` allows control over whether the SVG cursor is rendered optimised for speed or not.
 - New `TouchFree.ControlAnalyticsSession()` function that can start and stop an analytics session in the Service.
-- New `TouchFree.RegisterAnalyticEvents()` and `TouchFree.UnegisterAnalyticEvents()` functions to register / unregister non-TouchFree events (e.g. `pointerdown` or `touchstart`) to record analytics for
+- New `TouchFree.RegisterAnalyticEvents()` and `TouchFree.UnegisterAnalyticEvents()` functions to register / unregister non-TouchFree analytic events (e.g. `pointerdown` or `touchstart`)
 
 ## [1.4.0] - 2023-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New API to reset the interaction settings to their defaults.
 - `SVGCursor.SetCursorOptimise(bool)` allows control over whether the SVG cursor is rendered optimised for speed or not.
 - New `TouchFree.ControlAnalyticsSession()` function that can start and stop an analytics session in the Service.
+- New `TouchFree.RegisterAnalyticEvents()` and `TouchFree.UnegisterAnalyticEvents()` functions to register / unregister non-TouchFree events (e.g. `pointerdown` or `touchstart`) to record analytics for
 
 ## [1.4.0] - 2023-04-06
 

--- a/src/Connection/MessageReceiver.ts
+++ b/src/Connection/MessageReceiver.ts
@@ -114,14 +114,14 @@ export class MessageReceiver {
     // that are awaiting response from the Service.
     trackingStateCallbacks: { [id: string]: TrackingStateCallback } = {};
 
-    // Variable: analyticsSessionRequestQueue
-    // A queue of responses from RequestSessionStateChange calls.
-    analyticsSessionRequestQueue: WebSocketResponse[] = [];
+    // Variable: analyticsRequestQueue
+    // A queue of responses from service analytic calls.
+    analyticsRequestQueue: WebSocketResponse[] = [];
 
-    // Variable: analyticsSessionRequestCallbacks
+    // Variable: analyticsRequestCallbacks
     // A dictionary of unique request IDs and <ResponseCallback> that represent requests
     // that are awaiting response from the Service.
-    analyticsSessionRequestCallbacks: CallbackList<WebSocketResponse> = {};
+    analyticsRequestCallbacks: CallbackList<WebSocketResponse> = {};
 
     // Variable: callbackClearInterval
     // Stores the reference number for the interval running <ClearUnresponsiveCallbacks>, allowing
@@ -164,7 +164,7 @@ export class MessageReceiver {
         this.CheckQueue(this.trackingStateQueue, this.trackingStateCallbacks);
         this.CheckForAction();
         this.CheckForHandData();
-        this.CheckQueue(this.analyticsSessionRequestQueue, this.analyticsSessionRequestCallbacks);
+        this.CheckQueue(this.analyticsRequestQueue, this.analyticsRequestCallbacks);
     }
 
     // Function: CheckForHandshakeResponse

--- a/src/Connection/ServiceConnection.ts
+++ b/src/Connection/ServiceConnection.ts
@@ -201,7 +201,7 @@ export class ServiceConnection {
                 break;
             }
 
-            case ActionCode.ANALYTICS_UPDATE_COUNTS_REQUEST: {
+            case ActionCode.ANALYTICS_UPDATE_SESSION_EVENTS_REQUEST: {
                 ConnectionManager.messageReceiver.analyticsRequestQueue.push(looseData.content as WebSocketResponse);
                 break;
             }
@@ -460,9 +460,9 @@ export class ServiceConnection {
     ) => {
         const requestID = uuidgen();
         const content: SessionStateChangeRequest = {
-            requestID: requestID,
-            requestType: requestType,
-            sessionID: sessionID,
+            requestID,
+            requestType,
+            sessionID,
         };
         const wrapper = new CommunicationWrapper<SessionStateChangeRequest>(
             ActionCode.ANALYTICS_SESSION_REQUEST,
@@ -493,7 +493,7 @@ export class ServiceConnection {
             sessionEvents,
         };
         const wrapper = new CommunicationWrapper<UpdateAnalyticSessionEventsRequest>(
-            ActionCode.ANALYTICS_UPDATE_COUNTS_REQUEST,
+            ActionCode.ANALYTICS_UPDATE_SESSION_EVENTS_REQUEST,
             content
         );
         const message = JSON.stringify(wrapper);

--- a/src/Connection/ServiceConnection.ts
+++ b/src/Connection/ServiceConnection.ts
@@ -480,7 +480,8 @@ export class ServiceConnection {
         this.webSocket.send(message);
     };
 
-    // TODO.
+    // Function: UpdateAnalyticSessionEvents
+    // Used to send a request to update the analytic session's events stored in the Service
     UpdateAnalyticSessionEvents = (
         sessionID: string,
         sessionEvents: AnalyticSessionEvents,

--- a/src/Connection/ServiceConnection.ts
+++ b/src/Connection/ServiceConnection.ts
@@ -23,7 +23,8 @@ import {
     TrackingStateResponse,
     VersionHandshakeResponse,
     WebSocketResponse,
-    UpdateAnalyticEventCountsRequest,
+    UpdateAnalyticSessionEventsRequest,
+    AnalyticSessionEvents,
 } from './TouchFreeServiceTypes';
 import { v4 as uuidgen } from 'uuid';
 
@@ -479,16 +480,19 @@ export class ServiceConnection {
         this.webSocket.send(message);
     };
 
-    // Function: AnalyticsCountData
     // TODO.
-    UpdateAnalyticsEventCounts = (application: string, callback?: (detail: WebSocketResponse) => void) => {
+    UpdateAnalyticSessionEvents = (
+        sessionID: string,
+        sessionEvents: AnalyticSessionEvents,
+        callback?: (detail: WebSocketResponse) => void
+    ) => {
         const requestID = uuidgen();
-        const content: UpdateAnalyticEventCountsRequest = {
-            requestID: requestID,
-            application: application,
-            eventCounts: TouchFree.GetEventCounts(),
+        const content: UpdateAnalyticSessionEventsRequest = {
+            requestID,
+            sessionID,
+            sessionEvents,
         };
-        const wrapper = new CommunicationWrapper<UpdateAnalyticEventCountsRequest>(
+        const wrapper = new CommunicationWrapper<UpdateAnalyticSessionEventsRequest>(
             ActionCode.ANALYTICS_UPDATE_COUNTS_REQUEST,
             content
         );

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -80,7 +80,12 @@ export type AnalyticsSessionRequestType = 'START' | 'STOP';
 // Represents whether the event has been processed by the service
 export type EventStatus = 'PROCESSED' | 'UNPROCESSED';
 
+// Type: AnalyticEventKey
+// Supported analytic event types
 export type AnalyticEventKey = keyof DocumentEventMap;
+
+// Type: AnalyticSessionEvents
+// Indexed object storing how many times each analytics event has been called
 export type AnalyticSessionEvents = { [key in AnalyticEventKey]?: number };
 
 // Enum: HandPresenceState

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -29,7 +29,7 @@ import { Mask } from '../Tracking/TrackingTypes';
 // INTERACTION_ZONE_EVENT - Represents the interaction zone state received from the Service
 //
 // ANALYTICS_SESSION_REQUEST - Represents a request to start or stop an analytics session
-// ANALYTICS_UPDATE_COUNTS_REQUEST - Represents a request to update the analytic event counts for the current session.
+// ANALYTICS_UPDATE_SESSION_EVENTS_REQUEST - Represents a request to update the analytic events for the current session.
 export enum ActionCode {
     INPUT_ACTION = 'INPUT_ACTION',
 
@@ -68,7 +68,7 @@ export enum ActionCode {
     RESET_INTERACTION_CONFIG_FILE = 'RESET_INTERACTION_CONFIG_FILE',
 
     ANALYTICS_SESSION_REQUEST = 'ANALYTICS_SESSION_REQUEST',
-    ANALYTICS_UPDATE_COUNTS_REQUEST = 'ANALYTICS_UPDATE_COUNTS_REQUEST',
+    ANALYTICS_UPDATE_SESSION_EVENTS_REQUEST = 'ANALYTICS_UPDATE_SESSION_EVENTS_REQUEST',
 }
 
 // Type: RequestSessionStateChange

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -423,9 +423,9 @@ interface BaseAnalyticsRequest {
     sessionID: string;
 }
 
-// Interface: SessionStateChangeRequest
+// Interface: AnalyticsSessionStateChangeRequest
 // Represents a request to the service to change the state of an analytics session.
-export interface SessionStateChangeRequest extends BaseAnalyticsRequest {
+export interface AnalyticsSessionStateChangeRequest extends BaseAnalyticsRequest {
     // Variable: state
     requestType: AnalyticsSessionRequestType;
 }

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -414,24 +414,25 @@ export class SimpleRequest {
     }
 }
 
-// Interface: SessionStateChangeRequest
-// Represents a request to the service to change the state of an analytics session.
-export interface SessionStateChangeRequest {
+// Interface BaseAnalyticsRequest
+// Represents the base information needed for an Analytics related request to the Service
+interface BaseAnalyticsRequest {
     // Variable: requestID
     requestID: string;
-    // Variable: state
-    requestType: AnalyticsSessionRequestType;
     // Variable: sessionID
     sessionID: string;
 }
 
+// Interface: SessionStateChangeRequest
+// Represents a request to the service to change the state of an analytics session.
+export interface SessionStateChangeRequest extends BaseAnalyticsRequest {
+    // Variable: state
+    requestType: AnalyticsSessionRequestType;
+}
+
 // Interface: UpdateAnalyticSessionEventsRequest
 // Represents a request to the service to update the event counts in the current analytics session.
-export interface UpdateAnalyticSessionEventsRequest {
-    // Variable: requestID
-    requestID: string;
-    // Variable: sessionID
-    sessionID: string;
+export interface UpdateAnalyticSessionEventsRequest extends BaseAnalyticsRequest {
     // Variable: eventCounts
     sessionEvents: AnalyticSessionEvents;
 }

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -81,7 +81,7 @@ export type AnalyticsSessionRequestType = 'START' | 'STOP';
 export type EventStatus = 'PROCESSED' | 'UNPROCESSED';
 
 export type AnalyticEventKey = keyof DocumentEventMap;
-export type AnalyticEventCounts = { [key in AnalyticEventKey]?: number };
+export type AnalyticSessionEvents = { [key in AnalyticEventKey]?: number };
 
 // Enum: HandPresenceState
 // HAND_FOUND - Sent when the first hand is found when no hand has been present for a moment
@@ -420,15 +420,15 @@ export interface SessionStateChangeRequest {
     sessionID: string;
 }
 
-// Interface: UpdateAnalyticEventCountsRequest
+// Interface: UpdateAnalyticSessionEventsRequest
 // Represents a request to the service to update the event counts in the current analytics session.
-export interface UpdateAnalyticEventCountsRequest {
+export interface UpdateAnalyticSessionEventsRequest {
     // Variable: requestID
     requestID: string;
-    // Variable: application
-    application: string;
+    // Variable: sessionID
+    sessionID: string;
     // Variable: eventCounts
-    eventCounts: AnalyticEventCounts;
+    sessionEvents: AnalyticSessionEvents;
 }
 
 // Class: TrackingStateCallback

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -29,6 +29,7 @@ import { Mask } from '../Tracking/TrackingTypes';
 // INTERACTION_ZONE_EVENT - Represents the interaction zone state received from the Service
 //
 // ANALYTICS_SESSION_REQUEST - Represents a request to start or stop an analytics session
+// ANALYTICS_UPDATE_COUNTS_REQUEST - Represents a request to update the analytic event counts for the current session.
 export enum ActionCode {
     INPUT_ACTION = 'INPUT_ACTION',
 
@@ -67,6 +68,7 @@ export enum ActionCode {
     RESET_INTERACTION_CONFIG_FILE = 'RESET_INTERACTION_CONFIG_FILE',
 
     ANALYTICS_SESSION_REQUEST = 'ANALYTICS_SESSION_REQUEST',
+    ANALYTICS_UPDATE_COUNTS_REQUEST = 'ANALYTICS_UPDATE_COUNTS_REQUEST',
 }
 
 // Type: RequestSessionStateChange
@@ -77,6 +79,9 @@ export type AnalyticsSessionRequestType = 'START' | 'STOP';
 // Type: EventStatus
 // Represents whether the event has been processed by the service
 export type EventStatus = 'PROCESSED' | 'UNPROCESSED';
+
+export type AnalyticEventKey = keyof DocumentEventMap;
+export type AnalyticEventCounts = { [key in AnalyticEventKey]?: number };
 
 // Enum: HandPresenceState
 // HAND_FOUND - Sent when the first hand is found when no hand has been present for a moment
@@ -413,6 +418,17 @@ export interface SessionStateChangeRequest {
     requestType: AnalyticsSessionRequestType;
     // Variable: sessionID
     sessionID: string;
+}
+
+// Interface: UpdateAnalyticEventCountsRequest
+// Represents a request to the service to update the event counts in the current analytics session.
+export interface UpdateAnalyticEventCountsRequest {
+    // Variable: requestID
+    requestID: string;
+    // Variable: application
+    application: string;
+    // Variable: eventCounts
+    eventCounts: AnalyticEventCounts;
 }
 
 // Class: TrackingStateCallback

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -104,11 +104,8 @@ const ControlAnalyticsSession = (
             if (detail.status !== 'Failure') {
                 CurrentSessionId = newID;
                 analyticsHeartbeat = window.setInterval(
-                    () =>
-                        serviceConnection?.UpdateAnalyticSessionEvents(newID, sessionEvents, (e) =>
-                            console.log(e.message)
-                        ),
-                    1000
+                    () => serviceConnection?.UpdateAnalyticSessionEvents(newID, sessionEvents),
+                    2000
                 );
                 callback?.(detail);
             }
@@ -123,11 +120,11 @@ const ControlAnalyticsSession = (
         }
 
         serviceConnection?.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
-        serviceConnection?.UpdateAnalyticSessionEvents(CurrentSessionId, sessionEvents, (e) => console.log(e.message));
+        clearInterval(analyticsHeartbeat);
+        serviceConnection?.UpdateAnalyticSessionEvents(CurrentSessionId, sessionEvents);
         CurrentSessionId = undefined;
         // Clear session events
         sessionEvents = {};
-        clearInterval(analyticsHeartbeat);
     }
 };
 

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -67,7 +67,7 @@ const RegisterAnalyticEvents = (eventsIn: AnalyticEventKey[] = defaultAnalyticEv
 // Unregister any registered analytic events.
 // If no list of events is provided then all registered analytic events will be unregistered.
 const UnregisterAnalyticEvents = (eventsIn?: AnalyticEventKey[]) => {
-    const events: AnalyticEventKey[] = eventsIn ? eventsIn : (Object.keys(analyticEvents) as AnalyticEventKey[]);
+    const events: AnalyticEventKey[] = eventsIn ?? (Object.keys(analyticEvents) as AnalyticEventKey[]);
 
     events.forEach((evt) => {
         const evtFunc = analyticEvents[evt];

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -39,6 +39,40 @@ const Init = (tfInitParams?: TfInitParams): void => {
     }
 };
 
+type EventKey = keyof DocumentEventMap;
+const analyticEvents: { [key in EventKey]?: (e: Event) => void } = {};
+
+const defaultAnalyticEvents: EventKey[] = ['touchstart', 'touchmove', 'touchend'];
+
+// Function: RegisterAnalyticEvents
+// Registers a given list of event for the TouchFree service to record.
+// If no list of events is provided then the default set of events will be recorded.
+const RegisterAnalyticEvents = (eventsIn: EventKey[] = defaultAnalyticEvents) => {
+    eventsIn.forEach((evt) => {
+        const onEvent = (e: Event) => {
+            // SEND ANALYTIC EVENT TO SERVICE HERE
+            console.log(`${evt}:`, e);
+        };
+        analyticEvents[evt] = onEvent;
+        document.addEventListener(evt, onEvent, true);
+    });
+};
+
+// Function: UnregisterAnalyticEvents
+// Unregister any registered analytic events.
+// If no list of events is provided then all registered analytic events will be unregistered.
+const UnregisterAnalyticEvents = (eventsIn?: EventKey[]) => {
+    const events: EventKey[] = eventsIn ? eventsIn : (Object.keys(analyticEvents) as EventKey[]);
+
+    events.forEach((evt) => {
+        const evtFunc = analyticEvents[evt];
+        if (evtFunc) {
+            document.removeEventListener(evt, evtFunc, true);
+            delete analyticEvents[evt];
+        }
+    });
+};
+
 // Function: IsConnected
 // Are we connected to the TouchFree service?
 const IsConnected = (): boolean => ConnectionManager.IsConnected;
@@ -300,4 +334,6 @@ export default {
     IsConnected,
     RegisterEventCallback,
     ControlAnalytics: ControlAnalyticsSession,
+    RegisterAnalyticEvents,
+    UnregisterAnalyticEvents,
 };

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -119,12 +119,14 @@ const ControlAnalyticsSession = (
             return;
         }
 
-        serviceConnection?.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
         clearInterval(analyticsHeartbeat);
-        serviceConnection?.UpdateAnalyticSessionEvents(CurrentSessionId, sessionEvents);
-        CurrentSessionId = undefined;
-        // Clear session events
-        sessionEvents = {};
+        serviceConnection?.UpdateAnalyticSessionEvents(CurrentSessionId, sessionEvents, () => {
+            if (!CurrentSessionId) return;
+            // Clear session events
+            sessionEvents = {};
+            serviceConnection?.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
+            CurrentSessionId = undefined;
+        });
     }
 };
 

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -47,8 +47,8 @@ const Init = (tfInitParams?: TfInitParams): void => {
 const analyticEvents: { [key in AnalyticEventKey]?: () => void } = {};
 
 let sessionEvents: AnalyticSessionEvents = {};
-
 const defaultAnalyticEvents: AnalyticEventKey[] = ['touchstart', 'touchmove', 'touchend'];
+
 // Function: RegisterAnalyticEvents
 // Registers a given list of event for the TouchFree service to record.
 // If no list of events is provided then the default set of events will be recorded.
@@ -103,10 +103,13 @@ const ControlAnalyticsSession = (
         serviceConnection?.AnalyticsSessionRequest(requestType, newID, (detail) => {
             if (detail.status !== 'Failure') {
                 CurrentSessionId = newID;
-                // analyticsHeartbeat = window.setInterval(
-                //     () => serviceConnection?.UpdateAnalyticSessionEvents(newID, sessionEvents),
-                //     1000
-                // );
+                analyticsHeartbeat = window.setInterval(
+                    () =>
+                        serviceConnection?.UpdateAnalyticSessionEvents(newID, sessionEvents, (e) =>
+                            console.log(e.message)
+                        ),
+                    1000
+                );
                 callback?.(detail);
             }
         });

--- a/src/tests/TouchFree.test.ts
+++ b/src/tests/TouchFree.test.ts
@@ -105,10 +105,10 @@ describe('TouchFree', () => {
                     return requestType;
                 });
 
-            TouchFree.ControlAnalytics('START', applicationName);
+            TouchFree.ControlAnalyticsSession('START', applicationName);
             expect(testFn).toReturnWith('START');
 
-            TouchFree.ControlAnalytics('STOP', applicationName);
+            TouchFree.ControlAnalyticsSession('STOP', applicationName);
             expect(testFn).toReturnWith('STOP');
         });
 
@@ -127,9 +127,9 @@ describe('TouchFree', () => {
                 expect(arg).toBe(`Session: ${id} already in progress`);
             });
 
-            TouchFree.ControlAnalytics('START', applicationName);
-            TouchFree.ControlAnalytics('START', applicationName);
-            TouchFree.ControlAnalytics('STOP', applicationName);
+            TouchFree.ControlAnalyticsSession('START', applicationName);
+            TouchFree.ControlAnalyticsSession('START', applicationName);
+            TouchFree.ControlAnalyticsSession('STOP', applicationName);
             expect(testFn).toBeCalled();
         });
 
@@ -141,7 +141,7 @@ describe('TouchFree', () => {
                 expect(arg).toBe('No active session');
             });
 
-            TouchFree.ControlAnalytics('STOP', applicationName);
+            TouchFree.ControlAnalyticsSession('STOP', applicationName);
             expect(testFn).toBeCalled();
         });
     });

--- a/src/tests/TouchFree.test.ts
+++ b/src/tests/TouchFree.test.ts
@@ -93,6 +93,12 @@ describe('TouchFree', () => {
         beforeAll(() => {
             ConnectionManager.init();
             serviceConnection = ConnectionManager.serviceConnection();
+            if (!serviceConnection) fail('Service connection not available');
+            jest.spyOn(serviceConnection, 'UpdateAnalyticSessionEvents').mockImplementation(
+                (_sessionID, _sessionEvents, callback) => {
+                    callback?.(new WebSocketResponse('test', 'Success', 'test', 'test'));
+                }
+            );
         });
 
         it('should call AnalyticsSessionRequest with the correct arguments', () => {

--- a/src/tests/TouchFree.test.ts
+++ b/src/tests/TouchFree.test.ts
@@ -101,6 +101,8 @@ describe('TouchFree', () => {
             );
         });
 
+        afterAll(() => jest.clearAllMocks());
+
         it('should call AnalyticsSessionRequest with the correct arguments', () => {
             if (!serviceConnection) fail('Service connection not available');
             const testFn = jest


### PR DESCRIPTION
## Summary

Add ability to register / unregister non-TouchFree events (e.g. `pointerdown` or `touchstart`) to record analytics for.
When a session is started an update message is sent every 2 seconds to the service. The message acts as a heartbeat but clearing sessions based on dead heartbeats will be dealt with in a future PR

**TESTS TO BE ADDED IN A LATER PR**

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [x] Changelog updated with user-visible changes

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented