### PR TITLE
Give current session a unique ID

### DIFF
--- a/src/Connection/ServiceConnection.ts
+++ b/src/Connection/ServiceConnection.ts
@@ -450,14 +450,14 @@ export class ServiceConnection {
     // Used to either start a new analytics session, or stop the current session.
     AnalyticsSessionRequest = (
         requestType: AnalyticsSessionRequestType,
-        application: string,
+        sessionID: string,
         callback?: (detail: WebSocketResponse) => void
     ) => {
         const requestID = uuidgen();
         const content: SessionStateChangeRequest = {
             requestID: requestID,
             requestType: requestType,
-            application: application,
+            sessionID: sessionID,
         };
         const wrapper = new CommunicationWrapper<SessionStateChangeRequest>(
             ActionCode.ANALYTICS_SESSION_REQUEST,

--- a/src/Connection/TouchFreeServiceTypes.ts
+++ b/src/Connection/TouchFreeServiceTypes.ts
@@ -411,8 +411,8 @@ export interface SessionStateChangeRequest {
     requestID: string;
     // Variable: state
     requestType: AnalyticsSessionRequestType;
-    // Variable: application
-    application: string;
+    // Variable: sessionID
+    sessionID: string;
 }
 
 // Class: TrackingStateCallback

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -61,6 +61,7 @@ const ControlAnalyticsSession = (
 
         CurrentSessionId = `${application}:${uuidgen()}`;
         serviceConnection.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
+        return;
     }
 
     if (requestType === 'STOP') {

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -6,9 +6,11 @@ import { HandDataManager } from './Plugins/HandDataManager';
 import { InputActionManager } from './Plugins/InputActionManager';
 import { TouchFreeEvent, TouchFreeEventSignatures } from './TouchFreeToolingTypes';
 import { AnalyticsSessionRequestType, WebSocketResponse } from 'Connection/TouchFreeServiceTypes';
+import { v4 as uuidgen } from 'uuid';
 
 let InputController: WebInputController | undefined;
 let CurrentCursor: TouchlessCursor | undefined;
+let CurrentSessionId: string | undefined;
 
 // Class: TfInitParams
 // Extra options for use when initializing TouchFree
@@ -48,7 +50,28 @@ const ControlAnalyticsSession = (
     application: string,
     callback?: (detail: WebSocketResponse) => void
 ) => {
-    ConnectionManager.serviceConnection()?.AnalyticsSessionRequest(requestType, application, callback);
+    const serviceConnection = ConnectionManager.serviceConnection();
+    if (!serviceConnection) return;
+
+    if (requestType === 'START') {
+        if (CurrentSessionId) {
+            console.warn(`Session: ${CurrentSessionId} already in progress`);
+            return;
+        }
+
+        CurrentSessionId = `${application}:${uuidgen()}`;
+        serviceConnection.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
+    }
+
+    if (requestType === 'STOP') {
+        if (!CurrentSessionId) {
+            console.warn('No active session');
+            return;
+        }
+
+        serviceConnection.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
+        CurrentSessionId = undefined;
+    }
 };
 
 // Class: EventHandle

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -51,16 +51,18 @@ const ControlAnalyticsSession = (
     callback?: (detail: WebSocketResponse) => void
 ) => {
     const serviceConnection = ConnectionManager.serviceConnection();
-    if (!serviceConnection) return;
 
     if (requestType === 'START') {
         if (CurrentSessionId) {
             console.warn(`Session: ${CurrentSessionId} already in progress`);
             return;
         }
+        const newID = `${application}:${uuidgen()}`;
 
-        CurrentSessionId = `${application}:${uuidgen()}`;
-        serviceConnection.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
+        serviceConnection?.AnalyticsSessionRequest(requestType, newID, (detail) => {
+            CurrentSessionId = newID;
+            callback?.(detail);
+        });
         return;
     }
 
@@ -70,7 +72,7 @@ const ControlAnalyticsSession = (
             return;
         }
 
-        serviceConnection.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
+        serviceConnection?.AnalyticsSessionRequest(requestType, CurrentSessionId, callback);
         CurrentSessionId = undefined;
     }
 };

--- a/src/TouchFree.ts
+++ b/src/TouchFree.ts
@@ -60,8 +60,10 @@ const ControlAnalyticsSession = (
         const newID = `${application}:${uuidgen()}`;
 
         serviceConnection?.AnalyticsSessionRequest(requestType, newID, (detail) => {
-            CurrentSessionId = newID;
-            callback?.(detail);
+            if (detail.status !== 'Failure') {
+                CurrentSessionId = newID;
+                callback?.(detail);
+            }
         });
         return;
     }

--- a/src/tests/TouchFree.test.ts
+++ b/src/tests/TouchFree.test.ts
@@ -5,6 +5,7 @@ import { SVGCursor } from '../Cursors/SvgCursor';
 import { WebInputController } from '../InputControllers/WebInputController';
 import TouchFree from '../TouchFree';
 import { TouchFreeEventSignatures, TouchFreeEvent } from '../TouchFreeToolingTypes';
+import { ServiceConnection } from 'Connection/ServiceConnection';
 
 const events: TouchFreeEventSignatures = {
     OnConnected: jest.fn(),
@@ -85,62 +86,62 @@ describe('TouchFree', () => {
         expect(controller instanceof WebInputController).toBe(true);
     });
 
-    test('ControlAnalyticsSession should call AnalyticsSessionRequest with the correct arguments', () => {
-        ConnectionManager.init();
-        const serviceConnection = ConnectionManager.serviceConnection();
-        if (!serviceConnection) fail('Service connection not available');
-
+    describe('ControlAnalyticsSession', () => {
+        let serviceConnection: ServiceConnection | null = null;
         const applicationName = 'testApplication';
 
-        const testFn = jest
-            .spyOn(serviceConnection, 'AnalyticsSessionRequest')
-            .mockImplementation((requestType, sessionID, callback) => {
-                expect(sessionID.includes(applicationName)).toBe(true);
-                callback?.(new WebSocketResponse('test', 'Success', 'test', 'test'));
-                return requestType;
+        beforeAll(() => {
+            ConnectionManager.init();
+            serviceConnection = ConnectionManager.serviceConnection();
+        });
+
+        it('should call AnalyticsSessionRequest with the correct arguments', () => {
+            if (!serviceConnection) fail('Service connection not available');
+            const testFn = jest
+                .spyOn(serviceConnection, 'AnalyticsSessionRequest')
+                .mockImplementation((requestType, sessionID, callback) => {
+                    expect(sessionID.includes(applicationName)).toBe(true);
+                    callback?.(new WebSocketResponse('test', 'Success', 'test', 'test'));
+                    return requestType;
+                });
+
+            TouchFree.ControlAnalytics('START', applicationName);
+            expect(testFn).toReturnWith('START');
+
+            TouchFree.ControlAnalytics('STOP', applicationName);
+            expect(testFn).toReturnWith('STOP');
+        });
+
+        it('should give appropriate warnings on START', () => {
+            if (!serviceConnection) fail('Service connection not available');
+            let id = '';
+
+            jest.spyOn(serviceConnection, 'AnalyticsSessionRequest').mockImplementation(
+                (_arg1, sessionID, callback) => {
+                    id = sessionID;
+                    // This callback is here to mimic the Service sending a successful response
+                    callback?.(new WebSocketResponse('test', 'Success', 'test', 'test'));
+                }
+            );
+            jest.spyOn(console, 'warn').mockImplementation((arg) => {
+                expect(arg).toBe(`Session: ${id} already in progress`);
             });
 
-        TouchFree.ControlAnalytics('START', applicationName);
-        expect(testFn).toReturnWith('START');
-
-        TouchFree.ControlAnalytics('STOP', applicationName);
-        expect(testFn).toReturnWith('STOP');
-    });
-
-    test('ControlAnalyticsSession should give appropriate warnings on START', () => {
-        ConnectionManager.init();
-        const serviceConnection = ConnectionManager.serviceConnection();
-        if (!serviceConnection) fail('Service connection not available');
-
-        const applicationName = 'testApplication';
-
-        let id = '';
-
-        jest.spyOn(serviceConnection, 'AnalyticsSessionRequest').mockImplementation((_arg1, sessionID, callback) => {
-            id = sessionID;
-            callback?.(new WebSocketResponse('test', 'Success', 'test', 'test'));
-        });
-        jest.spyOn(console, 'warn').mockImplementation((arg) => {
-            expect(arg).toBe(`Session: ${id} already in progress`);
+            TouchFree.ControlAnalytics('START', applicationName);
+            TouchFree.ControlAnalytics('START', applicationName);
+            TouchFree.ControlAnalytics('STOP', applicationName);
         });
 
-        TouchFree.ControlAnalytics('START', applicationName);
-        TouchFree.ControlAnalytics('START', applicationName);
-        TouchFree.ControlAnalytics('STOP', applicationName);
-    });
+        it('should give appropriate warnings on STOP', () => {
+            if (!serviceConnection) fail('Service connection not available');
 
-    test('ControlAnalyticsSession should give appropriate warnings on STOP', () => {
-        ConnectionManager.init();
-        const serviceConnection = ConnectionManager.serviceConnection();
-        if (!serviceConnection) fail('Service connection not available');
+            jest.spyOn(serviceConnection, 'AnalyticsSessionRequest').mockImplementation(() => {});
+            const testFn = jest.spyOn(console, 'warn').mockImplementation((arg) => {
+                expect(arg).toBe('No active session');
+            });
 
-        const applicationName = 'testApplication';
-
-        jest.spyOn(serviceConnection, 'AnalyticsSessionRequest').mockImplementation(() => {});
-        jest.spyOn(console, 'warn').mockImplementation((arg) => {
-            expect(arg).toBe('No active session');
+            TouchFree.ControlAnalytics('STOP', applicationName);
+            expect(testFn).toBeCalled();
         });
-
-        TouchFree.ControlAnalytics('STOP', applicationName);
     });
 });

--- a/src/tests/TouchFree.test.ts
+++ b/src/tests/TouchFree.test.ts
@@ -123,13 +123,14 @@ describe('TouchFree', () => {
                     callback?.(new WebSocketResponse('test', 'Success', 'test', 'test'));
                 }
             );
-            jest.spyOn(console, 'warn').mockImplementation((arg) => {
+            const testFn = jest.spyOn(console, 'warn').mockImplementation((arg) => {
                 expect(arg).toBe(`Session: ${id} already in progress`);
             });
 
             TouchFree.ControlAnalytics('START', applicationName);
             TouchFree.ControlAnalytics('START', applicationName);
             TouchFree.ControlAnalytics('STOP', applicationName);
+            expect(testFn).toBeCalled();
         });
 
         it('should give appropriate warnings on STOP', () => {


### PR DESCRIPTION
## Summary

To allow Tooling to manage a unique ID for the analytics sessions.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [x] Changelog updated with user-visible changes

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented