### PR TITLE
Add disconnection event and reconnect in quick-start

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ build::bundle:
     # Package Tooling
     - mkdir ./Tooling_Release
     - cp ${CI_PROJECT_DIR}/Version.txt ./Tooling_Release
+    - cp ${CI_PROJECT_DIR}/CHANGELOG.md ./Tooling_Release
     - cp -R ${CI_PROJECT_DIR}/dist ./Tooling_Release
     - cp -R ${CI_PROJECT_DIR}/Plugins ./Tooling_Release
     - cp -R ${CI_PROJECT_DIR}/quick-start ./Tooling_Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generated markdown files detailing the public API.
 - An api report detailing the public API is now generated in `api/touchfree.api.md`.
 - `DeepPartial` type was added to support situations where all properties (nested included) of a type should be optional.
+- `TouchFreeServiceState` type to distinguish situations where no information is available when disconnected and full `ServiceState` information is available.
 - `onServiceStatusChange` event will now be sent with 'Disconnected' state when the TouchFree Service disconnects when it was previously connected.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generated markdown files detailing the public API.
 - An api report detailing the public API is now generated in `api/touchfree.api.md`.
 - `DeepPartial` type was added to support situations where all properties (nested included) of a type should be optional.
+- `onServiceStatusChange` event will now be sent with 'Disconnected' state when the TouchFree Service disconnects when it was previously connected.
 
 ### Changed
 

--- a/quick-start/main.js
+++ b/quick-start/main.js
@@ -84,3 +84,8 @@ touchfree.registerEventCallback('transmitInputAction', (action) => {
     if (!hovered) return;
     hovered.style.transform = `scale(${1.1 - action.ProgressToClick * 0.1})`;
 });
+
+touchfree.registerEventCallback('onServiceStatusChange', (state) => {
+    if (state !== 'Disconnected') return;
+    setTimeout(touchfree.connect, 5000);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ export type {
     /** Connection - Manage a connection to the TouchFree service and messages send or receive messages */
     Address,
     ServiceState,
+    TouchFreeServiceState,
     ResponseState,
     ResponseCallback,
 

--- a/src/internal/Connection/ConnectionApi.ts
+++ b/src/internal/Connection/ConnectionApi.ts
@@ -55,9 +55,10 @@ export function getServiceConnection(): ServiceConnection | null {
  * A successful connection will dispatch the `"onConnected"` event.
  * @public
  */
-export function connect(address: Address = defaultConnectionAddress): void {
+export function connect(address: Address = defaultConnectionAddress): ServiceConnection {
     currentServiceConnection = new ServiceConnection(address);
     currentConnectionAddress = address;
+    return currentServiceConnection;
 }
 
 /**

--- a/src/internal/Connection/ConnectionTypes.ts
+++ b/src/internal/Connection/ConnectionTypes.ts
@@ -63,6 +63,12 @@ export enum InteractionZoneState {
 }
 
 /**
+ * State of the service if connected
+ * @public
+ */
+export type TouchFreeServiceState = ServiceState | 'Disconnected';
+
+/**
  * State including TouchFree service/config, tracking service and camera
  * @public
  */

--- a/src/internal/Connection/ServiceConnection.ts
+++ b/src/internal/Connection/ServiceConnection.ts
@@ -140,7 +140,7 @@ export class ServiceConnection {
         this.handshakeRequested = false;
         this.handshakeCompleted = false;
 
-        this.webSocket.addEventListener('error', (ev) => console.error(ev));
+        this.webSocket.addEventListener('error', console.error);
         this.webSocket.addEventListener('close', (_ev) => {
             if (this.handshakeCompleted) {
                 dispatchEventCallback('onServiceStatusChange', 'Disconnected');

--- a/src/internal/Connection/ServiceConnection.ts
+++ b/src/internal/Connection/ServiceConnection.ts
@@ -140,6 +140,14 @@ export class ServiceConnection {
         this.handshakeRequested = false;
         this.handshakeCompleted = false;
 
+        this.webSocket.addEventListener('error', (ev) => console.error(ev));
+        this.webSocket.addEventListener('close', (_ev) => {
+            if (this.handshakeCompleted) {
+                dispatchEventCallback('onServiceStatusChange', 'Disconnected');
+                console.log('Disconnected from TouchFree Service');
+            }
+        });
+
         this.webSocket.addEventListener('open', this.requestHandshake, { once: true });
     }
 
@@ -189,7 +197,7 @@ export class ServiceConnection {
      */
     private connectionResultCallback = (response: VersionHandshakeResponse | WebSocketResponse): void => {
         if (response.status === 'Success') {
-            console.log('Successful Connection');
+            console.log('Successful Connection to TouchFree Service');
             const handshakeResponse = response as VersionHandshakeResponse;
             if (handshakeResponse) {
                 this.internalTouchFreeVersion = handshakeResponse.touchFreeVersion;

--- a/src/internal/TouchFreeEvents/TouchFreeEvents.ts
+++ b/src/internal/TouchFreeEvents/TouchFreeEvents.ts
@@ -24,7 +24,7 @@ export interface TouchFreeEventSignatures {
     onTrackingServiceStateChange: (state: TrackingServiceState) => void;
     /**
      * Event dispatched when the status of TouchFree Service changes.
-     * An event for 'Disconnected' will be sent only if it was connected before.
+     * An event for 'Disconnected' will only be sent if a connection was already established
      */
     onServiceStatusChange: (state: ServiceState | 'Disconnected') => void;
     /**

--- a/src/internal/TouchFreeEvents/TouchFreeEvents.ts
+++ b/src/internal/TouchFreeEvents/TouchFreeEvents.ts
@@ -23,9 +23,10 @@ export interface TouchFreeEventSignatures {
      */
     onTrackingServiceStateChange: (state: TrackingServiceState) => void;
     /**
-     * Event dispatched when the status of TouchFree Service changes
+     * Event dispatched when the status of TouchFree Service changes.
+     * An event for 'Disconnected' will be sent only if it was connected before.
      */
-    onServiceStatusChange: (state: ServiceState) => void;
+    onServiceStatusChange: (state: ServiceState | 'Disconnected') => void;
     /**
      * Event dispatched when the first hand has started tracking
      */

--- a/src/internal/TouchFreeEvents/TouchFreeEvents.ts
+++ b/src/internal/TouchFreeEvents/TouchFreeEvents.ts
@@ -1,5 +1,5 @@
 import { isConnected } from '../Connection/ConnectionApi';
-import { type ServiceState, TrackingServiceState } from '../Connection/ConnectionTypes';
+import { type TouchFreeServiceState, TrackingServiceState } from '../Connection/ConnectionTypes';
 import { HandFrame } from '../Hands/HandFrame';
 import { type TouchFreeInputAction } from '../InputActions/InputAction';
 import { LicenseState } from '../Licensing/LicensingTypes';
@@ -26,7 +26,7 @@ export interface TouchFreeEventSignatures {
      * Event dispatched when the status of TouchFree Service changes.
      * An event for 'Disconnected' will only be sent if a connection was already established
      */
-    onServiceStatusChange: (state: ServiceState | 'Disconnected') => void;
+    onServiceStatusChange: (state: TouchFreeServiceState) => void;
     /**
      * Event dispatched when the first hand has started tracking
      */


### PR DESCRIPTION
## Summary

_Summary of the purpose of this pull request._

Add an event when disconnecting from the service via websocket close.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [x] Changelog updated with user-visible changes

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented