### PR TITLE
Release/Tooling_for_Web/1.4.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
   BS_EXTENSION_NAME: ultouchfree
 
   TF_TFU_VERSION: '1.1.0'
-  TF_TFW_VERSION: '1.4.0'
+  TF_TFW_VERSION: '1.4.1-beta'
   TOUCHFREE_VERSION: '2.6.0'
 
   TF_TOOLING_API_VERSION: '1.4.0'

--- a/TF_Tooling_Web/CHANGELOG.md
+++ b/TF_Tooling_Web/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the TouchFree Web Tooling project are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.1] - 2023-10-18
+## [1.4.1-beta] - 2023-10-18
 
 ### Changed
 

--- a/TF_Tooling_Web/CHANGELOG.md
+++ b/TF_Tooling_Web/CHANGELOG.md
@@ -9,7 +9,13 @@ All notable changes to the TouchFree Web Tooling project are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.1] - 2023-10-18
+
+### Changed
+
+- `OnServiceStatusChange` event will now be sent with 'Disconnected' state when the TouchFree Service disconnects when it was previously connected.
+
+## [1.4.0] - 2023-04-06
 
 ### Added
 

--- a/TF_Tooling_Web/package.json
+++ b/TF_Tooling_Web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchfree",
-  "version": "1.4.0",
+  "version": "1.4.1-beta",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/TF_Tooling_Web/quick-start/Quick-Start_Example.html
+++ b/TF_Tooling_Web/quick-start/Quick-Start_Example.html
@@ -97,6 +97,12 @@
         // This is the only call required to initialise TouchFree tooling, getting a default cursor
         TouchFree.Init();
 
+        // Attempt to reconnect to TouchFree Service after a disconnect
+        TouchFree.RegisterEventCallback('OnServiceStatusChange', (state) => {
+            if (state !== 'Disconnected') return;
+            setTimeout(TouchFree.Connection.ConnectionManager.Connect, 5000);
+        });
+
         var changeText = function (content) {
             var textToChange = document.getElementById("Text to change");
             textToChange.textContent = content;

--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -101,11 +101,10 @@ export class ConnectionManager extends EventTarget {
     // Function: Connect
     // Creates a new <ServiceConnection> using <iPAddress> and <port>.
     // Also invokes <OnConnected> on all listeners.
-    public static Connect(): void {
-        ConnectionManager.currentServiceConnection = new ServiceConnection(
-            ConnectionManager.iPAddress,
-            ConnectionManager.port
-        );
+    public static Connect(): ServiceConnection {
+        const connection = new ServiceConnection(ConnectionManager.iPAddress, ConnectionManager.port);
+        ConnectionManager.currentServiceConnection = connection;
+        return connection;
     }
 
     // Function: HandleHandPresenceEvent

--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -101,10 +101,11 @@ export class ConnectionManager extends EventTarget {
     // Function: Connect
     // Creates a new <ServiceConnection> using <iPAddress> and <port>.
     // Also invokes <OnConnected> on all listeners.
-    public static Connect(): ServiceConnection {
-        const connection = new ServiceConnection(ConnectionManager.iPAddress, ConnectionManager.port);
-        ConnectionManager.currentServiceConnection = connection;
-        return connection;
+    public static Connect(): void {
+        ConnectionManager.currentServiceConnection = new ServiceConnection(
+            ConnectionManager.iPAddress,
+            ConnectionManager.port
+        );
     }
 
     // Function: HandleHandPresenceEvent

--- a/TF_Tooling_Web/src/Connection/ServiceConnection.ts
+++ b/TF_Tooling_Web/src/Connection/ServiceConnection.ts
@@ -66,6 +66,14 @@ export class ServiceConnection {
         this.handshakeRequested = false;
         this.handshakeCompleted = false;
 
+        this.webSocket.addEventListener('error', console.error);
+        this.webSocket.addEventListener('close', (_ev) => {
+            if (this.handshakeCompleted) {
+                TouchFree.DispatchEvent('OnServiceStatusChange', 'Disconnected');
+                console.log('Disconnected from TouchFree Service');
+            }
+        });
+
         this.webSocket.addEventListener('open', this.RequestHandshake, { once: true });
     }
 

--- a/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
+++ b/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
@@ -177,7 +177,7 @@ export interface TouchFreeEventSignatures {
     OnConnected: () => void;
     WhenConnected: () => void;
     OnTrackingServiceStateChange: (state: TrackingServiceState) => void;
-    OnServiceStatusChange: (state: ServiceStatus) => void;
+    OnServiceStatusChange: (state: ServiceStatus | 'Disconnected') => void;
     HandFound: () => void;
     HandsLost: () => void;
     TransmitHandData: (data: HandFrame) => void;


### PR DESCRIPTION
https://ultrahaptics.atlassian.net/browse/TF-1615

Hotfix release for customer.
Adds 'Disconnected' state to `OnServiceStatusChange` allowing the app to handle this event (i.e. by requesting a reconnection)

To detect disconnects register for `OnServiceStatusChange` and handle the value if it is 'Disconnect'. e.g.:

> Touchfree.RegisterEventCallback('OnServiceStatusChange', (state) => {
>     if (state !== 'Disconnected') return;
>     setTimeout(TouchFree.Connection.ConnectionManager.Connect, 5000);
> });

!! Reconnecting (like the above example) will re-trigger `OnConnected`. This means any event listeners added during `OnConnect` will be re-added which can result in multiple event listeners. This should be handled on the application side (by checking if they are already added or removing listeners on a disconnect)

DO NOT MERGE!